### PR TITLE
Fix run retrieval parameter order in gmAssistants

### DIFF
--- a/Desktop/NEW GM/ai-gm-week2/apps/server/src/gmAssistants.ts
+++ b/Desktop/NEW GM/ai-gm-week2/apps/server/src/gmAssistants.ts
@@ -99,8 +99,10 @@ router.post("/run", async (req, res) => {
       
       await sleep(800);
       
-      // Fixed: Correct parameter order for retrieving a run
-      const latest = await client.beta.threads.runs.retrieve(threadId, run.id);
+      // Fixed: Retrieve run by passing the run ID first and thread ID as a param object
+      const latest = await client.beta.threads.runs.retrieve(run.id, {
+        thread_id: threadId,
+      });
       status = latest.status;
       console.log("[/api/gm/run] Run status:", status);
     }


### PR DESCRIPTION
## Summary
- pass thread ID via params object when retrieving runs, matching RunRetrieveParams type

## Testing
- `npm run build:server`


------
https://chatgpt.com/codex/tasks/task_e_68bdbddfd3ec8325b470e9bcbc7bc09a