### PR TITLE
Persist client state across reloads

### DIFF
--- a/Desktop/NEW GM/ai-gm-week2/apps/client/src/App.tsx
+++ b/Desktop/NEW GM/ai-gm-week2/apps/client/src/App.tsx
@@ -130,17 +130,34 @@ function CampaignList({ onBack }: { onBack: () => void }) {
 }
 
 export default function App() {
-  const [screen, setScreen] = React.useState<Screen>('auth')
+  const [screen, setScreen] = React.useState<Screen>(() => {
+    const saved = localStorage.getItem('screen') as Screen | null
+    return saved || 'auth'
+  })
   const [ready, setReady] = React.useState(false)
 
   React.useEffect(() => {
+    localStorage.setItem('screen', screen)
+  }, [screen])
+
+  React.useEffect(() => {
     supabase.auth.getSession().then(({ data }) => {
-      setScreen(data.session ? 'start' : 'auth')
+      if (data.session) {
+        const saved = localStorage.getItem('screen') as Screen | null
+        setScreen(saved && saved !== 'auth' ? saved : 'start')
+      } else {
+        setScreen('auth')
+      }
       setReady(true)
     })
-    const { data: sub } = supabase.auth.onAuthStateChange((_e, session) =>
-      setScreen(session ? 'start' : 'auth')
-    )
+    const { data: sub } = supabase.auth.onAuthStateChange((_e, session) => {
+      if (session) {
+        const saved = localStorage.getItem('screen') as Screen | null
+        setScreen(saved && saved !== 'auth' ? saved : 'start')
+      } else {
+        setScreen('auth')
+      }
+    })
     return () => {
       sub.subscription.unsubscribe()
     }


### PR DESCRIPTION
## Summary
- store last active screen in localStorage so session resumes after tab switches
- persist GM chat thread and log in localStorage

## Testing
- `npm --prefix "Desktop/NEW GM/ai-gm-week2" run build:client`
- `npm --prefix "Desktop/NEW GM/ai-gm-week2" run build:server`


------
https://chatgpt.com/codex/tasks/task_e_68bdcfab864083259b5e8d48edc5e942