### PR TITLE
Remove unused Start chat bubble

### DIFF
--- a/Desktop/NEW GM/ai-gm-week2/apps/client/src/GmChat.tsx
+++ b/Desktop/NEW GM/ai-gm-week2/apps/client/src/GmChat.tsx
@@ -27,7 +27,7 @@ export default function GmChat() {
         const { threadId: newThreadId } = await r.json();
         console.log('[GmChat] Thread created:', newThreadId);
         setThreadId(newThreadId);
-        await sendInternal(newThreadId, 'Start');
+        await sendInternal(newThreadId, 'Start', { silent: true });
       } catch (e: any) {
         console.error('[GmChat] Failed to create thread:', e);
         setError('Nie udało się połączyć z Mistrzem Gry. Spróbuj wysłać wiadomość ponownie.');
@@ -59,9 +59,15 @@ export default function GmChat() {
     return newThreadId;
   }
 
-  async function sendInternal(currentThreadId: string, text: string) {
+  async function sendInternal(
+    currentThreadId: string,
+    text: string,
+    opts?: { silent?: boolean }
+  ) {
     console.log('[GmChat] sendInternal called with:', { currentThreadId, text });
-    setLog((l) => [...l, { from: 'me', text }]);
+    if (!opts?.silent) {
+      setLog((l) => [...l, { from: 'me', text }]);
+    }
     setBusy(true);
     setError('');
     


### PR DESCRIPTION
## Summary
- hide the automatically sent "Start" message from appearing in GM chat

## Testing
- `npm --prefix Desktop/'NEW GM'/ai-gm-week2/apps/client test` (fails: Missing script "test")
- `npm --prefix Desktop/'NEW GM'/ai-gm-week2/apps/server test` (fails: Missing script "test")
- `npm --prefix Desktop/'NEW GM'/ai-gm-week2/apps/client run build` (fails: Cannot find module 'react' or its corresponding type declarations)
- `npm --prefix Desktop/'NEW GM'/ai-gm-week2/apps/server run build` (fails: Cannot find module 'express' or its corresponding type declarations)


------
https://chatgpt.com/codex/tasks/task_e_68bddc7d1a04832580272890e1172070