### PR TITLE
Narrate GM responses using male voice

### DIFF
--- a/Desktop/NEW GM/ai-gm-week2/README.md
+++ b/Desktop/NEW GM/ai-gm-week2/README.md
@@ -5,6 +5,7 @@ Gotowy kod na **Tydzień 2**:
 - Ekran startowy: **Nowa kampania** / **Kontynuuj**
 - **Lista kampanii** użytkownika, tworzenie nowej, wybór kampanii do kontynuacji
 - Serwer Express (CJS) zostawiamy — endpoint `/health` i `/api/roll` jak wcześniej
+- Odpowiedzi Mistrza Gry są czytane męskim głosem narratora (Web Speech API)
 
 ## Wymagania
 - Node >= 20

--- a/Desktop/NEW GM/ai-gm-week2/apps/client/src/GmChat.tsx
+++ b/Desktop/NEW GM/ai-gm-week2/apps/client/src/GmChat.tsx
@@ -16,6 +16,23 @@ export default function GmChat() {
 
   const base = import.meta.env.VITE_API_BASE as string;
 
+  React.useEffect(() => {
+    if ('speechSynthesis' in window) {
+      window.speechSynthesis.getVoices();
+    }
+  }, []);
+
+  function speak(text: string) {
+    if (!('speechSynthesis' in window)) return;
+    const synth = window.speechSynthesis;
+    const utter = new SpeechSynthesisUtterance(text);
+    const voices = synth.getVoices();
+    const male = voices.find(v => /male|man|adam|jan|jacek|daniel|david/i.test(v.name));
+    if (male) utter.voice = male;
+    utter.pitch = 0.8;
+    synth.speak(utter);
+  }
+
   // Try to auto-create a thread on mount (non-blocking)
   React.useEffect(() => {
     if (threadId) return;
@@ -95,6 +112,7 @@ export default function GmChat() {
       }
       const { reply } = await r2.json();
       setLog((l) => [...l, { from: 'gm', text: reply }]);
+      speak(reply);
     } catch (e: any) {
       console.error('[GmChat] Error in sendInternal:', e);
       setError('Problem z odpowiedzią MG. Sprawdź połączenie i spróbuj ponownie.');


### PR DESCRIPTION
## Summary
- Speak Game Master replies aloud using Web Speech API, selecting a male voice when available
- Document narrator voice feature in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build:client` *(fails: Cannot find module 'react' or its types)*
- `npm run build:server` *(fails: Cannot find module 'express' or its types)*

------
https://chatgpt.com/codex/tasks/task_e_68bddefde41c8325a6a722833a22ba36