### PR TITLE
Use Eleven Labs voice for GM replies

### DIFF
--- a/Desktop/NEW GM/ai-gm-week2/apps/client/src/GmChat.tsx
+++ b/Desktop/NEW GM/ai-gm-week2/apps/client/src/GmChat.tsx
@@ -16,21 +16,21 @@ export default function GmChat() {
 
   const base = import.meta.env.VITE_API_BASE as string;
 
-  React.useEffect(() => {
-    if ('speechSynthesis' in window) {
-      window.speechSynthesis.getVoices();
+  async function speak(text: string) {
+    try {
+      const r = await fetch(`${base}/api/gm/speech`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text }),
+      });
+      if (!r.ok) throw new Error(`speech ${r.status}`);
+      const blob = await r.blob();
+      const url = URL.createObjectURL(blob);
+      const audio = new Audio(url);
+      audio.play();
+    } catch (e) {
+      console.error('[GmChat] TTS error:', e);
     }
-  }, []);
-
-  function speak(text: string) {
-    if (!('speechSynthesis' in window)) return;
-    const synth = window.speechSynthesis;
-    const utter = new SpeechSynthesisUtterance(text);
-    const voices = synth.getVoices();
-    const male = voices.find(v => /male|man|adam|jan|jacek|daniel|david/i.test(v.name));
-    if (male) utter.voice = male;
-    utter.pitch = 0.8;
-    synth.speak(utter);
   }
 
   // Try to auto-create a thread on mount (non-blocking)

--- a/Desktop/NEW GM/ai-gm-week2/apps/server/src/gmAssistants.ts
+++ b/Desktop/NEW GM/ai-gm-week2/apps/server/src/gmAssistants.ts
@@ -146,4 +146,43 @@ router.post("/run", async (req, res) => {
   }
 });
 
+router.post("/speech", async (req, res) => {
+  try {
+    const { text } = req.body ?? {};
+    const key = process.env.ELEVENLABS_KEY;
+    const voice = process.env.VOICE_ID;
+
+    if (!text) {
+      return res.status(400).json({ error: "text required" });
+    }
+    if (!key || !voice) {
+      console.warn("[gmAssistants] Missing ELEVENLABS_KEY or VOICE_ID");
+      return res.status(500).json({ error: "tts not configured" });
+    }
+
+    const r = await fetch(`https://api.elevenlabs.io/v1/text-to-speech/${voice}`, {
+      method: "POST",
+      headers: {
+        "xi-api-key": key,
+        Accept: "audio/mpeg",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ text }),
+    });
+
+    if (!r.ok) {
+      const err = await r.text();
+      console.error("[/api/gm/speech] TTS failed:", r.status, err);
+      return res.status(500).json({ error: "tts failed", detail: err });
+    }
+
+    const buf = Buffer.from(await r.arrayBuffer());
+    res.setHeader("Content-Type", "audio/mpeg");
+    res.send(buf);
+  } catch (e: any) {
+    console.error("[/api/gm/speech] error:", e?.message || e);
+    res.status(500).json({ error: "tts error", detail: String(e?.message || e) });
+  }
+});
+
 export default router;


### PR DESCRIPTION
## Summary
- add `/api/gm/speech` endpoint that calls Eleven Labs with `ELEVENLABS_KEY` and `VOICE_ID`
- update `GmChat` to fetch generated audio instead of browser speech synthesis

## Testing
- `npm test` (apps/server) *(fails: Missing script "test")*
- `npm run build` (apps/server) *(fails: Cannot find module 'express' or its corresponding type declarations)*
- `npm test` (apps/client) *(fails: Missing script "test")*
- `npm run build` (apps/client) *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68bde2ad36c08325ad5f432ae99b0e99