### PR TITLE
feat: add voice input and GM setup options

### DIFF
--- a/Desktop/NEW GM/ai-gm-week2/apps/client/src/App.tsx
+++ b/Desktop/NEW GM/ai-gm-week2/apps/client/src/App.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { supabase, signIn, signUp, signOut, fetchCampaigns, createCampaign, type Campaign } from './supabaseClient'
 import GmChat from './GmChat'
 
-type Screen = 'auth' | 'start' | 'new' | 'list' | 'gm'
+type Screen = 'auth' | 'start' | 'new' | 'list' | 'gm' | 'gmsetup'
 
 function AuthScreen({ onDone }: { onDone: () => void }) {
   const [email, setEmail] = React.useState('')
@@ -129,12 +129,68 @@ function CampaignList({ onBack, onOpen }: { onBack: () => void; onOpen: (id: str
   )
 }
 
+function GmSetup({
+  onBack,
+  onStart,
+}: {
+  onBack: () => void
+  onStart: (players: number, mode: 'custom' | 'random') => void
+}) {
+  const [players, setPlayers] = React.useState<number | null>(null)
+
+  if (players === null) {
+    return (
+      <div
+        style={{
+          maxWidth: 640,
+          margin: '64px auto',
+          fontFamily: 'system-ui',
+          display: 'grid',
+          gap: 12,
+        }}
+      >
+        <h2>Wybierz liczbę graczy</h2>
+        <div style={{ display: 'flex', gap: 8 }}>
+          {[1, 2, 3, 4].map((n) => (
+            <button key={n} onClick={() => setPlayers(n)}>
+              {n}
+            </button>
+          ))}
+        </div>
+        <button onClick={onBack}>Wróć</button>
+      </div>
+    )
+  }
+
+  return (
+    <div
+      style={{
+        maxWidth: 640,
+        margin: '64px auto',
+        fontFamily: 'system-ui',
+        display: 'grid',
+        gap: 12,
+      }}
+    >
+      <h2>{players} gracze. Jak rozpocząć?</h2>
+      <button onClick={() => onStart(players, 'custom')}>
+        Tworzymy postacie i fabułę
+      </button>
+      <button onClick={() => onStart(players, 'random')}>
+        Losuj postacie i fabułę
+      </button>
+      <button onClick={() => setPlayers(null)}>Wróć</button>
+    </div>
+  )
+}
+
 export default function App() {
   const [screen, setScreen] = React.useState<Screen>(() => {
     const saved = localStorage.getItem('screen') as Screen | null
     return saved || 'auth'
   })
   const [currentCampaignId, setCurrentCampaignId] = React.useState<string | null>(null)
+  const [gmOptions, setGmOptions] = React.useState<{ players: number; mode: 'custom' | 'random' } | null>(null)
   const [ready, setReady] = React.useState(false)
 
   React.useEffect(() => {
@@ -178,7 +234,35 @@ export default function App() {
       />
     )
   if (screen === 'gm' && currentCampaignId)
-    return <GmChat campaignId={currentCampaignId} onBack={() => setScreen('start')} />
+    return (
+      <GmChat
+        campaignId={currentCampaignId}
+        setup={gmOptions ?? undefined}
+        onBack={() => {
+          setScreen('start')
+          setGmOptions(null)
+        }}
+      />
+    )
+  if (screen === 'gmsetup')
+    return (
+      <GmSetup
+        onBack={() => setScreen('start')}
+        onStart={async (players, mode) => {
+          try {
+            const c = await createCampaign({
+              title: `Kampania ${new Date().toLocaleString()}`,
+              world: 'fantasy',
+            })
+            setCurrentCampaignId(c.id)
+            setGmOptions({ players, mode })
+            setScreen('gm')
+          } catch (e: any) {
+            alert(e.message || 'Błąd tworzenia kampanii')
+          }
+        }}
+      />
+    )
 
   return (
     <StartScreen
@@ -188,18 +272,7 @@ export default function App() {
         await signOut()
         setScreen('auth')
       }}
-      onGM={async () => {
-        try {
-          const c = await createCampaign({
-            title: `Kampania ${new Date().toLocaleString()}`,
-            world: 'fantasy',
-          })
-          setCurrentCampaignId(c.id)
-          setScreen('gm')
-        } catch (e: any) {
-          alert(e.message || 'Błąd tworzenia kampanii')
-        }
-      }}
+      onGM={() => setScreen('gmsetup')}
     />
   )
 }


### PR DESCRIPTION
## Summary
- add setup flow for GM campaigns with player count and character/plot options
- allow voice input in GM chat using browser speech recognition

## Testing
- `npm test` *(client)*
- `npm run build` *(client)*
- `npm test` *(server)*
- `npm run build` *(server)*

------
https://chatgpt.com/codex/tasks/task_e_68bdea17c23c8325bb6b449b909db3a0