### PR TITLE
fix: preserve player choices and refine GM prompt

### DIFF
--- a/Desktop/NEW GM/ai-gm-week2/apps/client/src/GmChat.tsx
+++ b/Desktop/NEW GM/ai-gm-week2/apps/client/src/GmChat.tsx
@@ -79,13 +79,14 @@ export default function GmChat({
         const { threadId: newThreadId } = await r.json();
         console.log('[GmChat] Thread created:', newThreadId);
         setThreadId(newThreadId);
-        let intro = 'Start';
+        let intro =
+          'Start. Pamiętaj wszystkie wybory graczy i nie rozpoczynaj odpowiedzi od "Zrozumiałem!".';
         if (setup) {
           intro = `Start kampanii dla ${setup.players} graczy. ${
             setup.mode === 'custom'
               ? 'Stworzymy własne postacie i zarys fabuły.'
               : 'Proszę wylosuj postacie i zarys fabuły.'
-          }`;
+          } Pamiętaj wszystkie wybory graczy i nie rozpoczynaj odpowiedzi od "Zrozumiałem!".`;
         }
         await sendInternal(newThreadId, intro, { silent: true });
       } catch (e: any) {
@@ -110,7 +111,9 @@ export default function GmChat({
   }, [playerInfo, infoKey]);
 
   function updatePlayerInfo(text: string) {
-    const nameMatch = text.match(/nazywa si[eę]\s+([A-Za-ząćęłńóśźżĄĆĘŁŃÓŚŹŻ]+)/i);
+    const nameMatch =
+      text.match(/nazywa si[eę]\s+([A-Za-ząćęłńóśźżĄĆĘŁŃÓŚŹŻ]+)/i) ||
+      text.match(/to\s+([A-Za-ząćęłńóśźżĄĆĘŁŃÓŚŹŻ]+)\s+(?:jest|będzie)/i);
     const classMatch = text.match(/(?:jest|będzie)\s+([A-Za-ząćęłńóśźżĄĆĘŁŃÓŚŹŻ]+)/i);
     if (nameMatch || classMatch) {
       setPlayerInfo((info) => ({
@@ -141,9 +144,6 @@ export default function GmChat({
     opts?: { silent?: boolean }
   ) {
     console.log('[GmChat] sendInternal called with:', { currentThreadId, text });
-    const history = log
-      .map((m) => `${m.from === 'me' ? 'Gracz' : 'MG'}: ${m.text}`)
-      .join('\n');
     if (!opts?.silent) {
       setLog((l) => [...l, { from: 'me', text }]);
     }
@@ -159,7 +159,7 @@ export default function GmChat({
               playerInfo.name ? playerInfo.name : ''
             }${playerInfo.class ? `, klasa ${playerInfo.class}` : ''}.`
           : '';
-      const parts = [preamble, history, `Gracz: ${text}`].filter(Boolean);
+      const parts = [preamble, `Gracz: ${text}`].filter(Boolean);
       const fullText = parts.join('\n');
       const r1 = await fetch(`${base}/api/gm/message`, {
         method: 'POST',

--- a/Desktop/NEW GM/ai-gm-week2/apps/server/INSTRUCTIONS.md
+++ b/Desktop/NEW GM/ai-gm-week2/apps/server/INSTRUCTIONS.md
@@ -1,0 +1,73 @@
+🎮 Jesteś AI-Mistrzem Gry (Mistrzem Gry) prowadzącym epicką, nieliniową kampanię fantasy. Twoim zadaniem jest tworzenie pełnej narracji, reagowanie na decyzje graczy i prowadzenie immersyjnej rozgrywki w języku polskim.
+
+---
+
+📌 WAŻNE: Aplikacja przesyła wybory gracza w postaci tekstu. Zawsze analizuj je uważnie.
+
+Jeśli otrzymasz wiadomość zawierającą:
+
+- Postacie: **Stworzymy własne**  
+→ Natychmiast zatrzymaj narrację i przeprowadź **kreator postaci**.  
+❗ Nie wolno ci opisywać, tworzyć ani wprowadzać żadnych postaci.  
+Zacznij od pytania o imię i klasę postaci. Następnie zapytaj o wygląd lub charakter. Na końcu wylosuj uproszczone statystyki.  
+Nie przechodź do przygody, dopóki nie stworzysz każdej postaci.
+
+- Postacie: **Losowe**  
+→ Samodzielnie stwórz i narracyjnie przedstaw postacie dla graczy.
+
+- Kampania: **Własna**  
+→ Zatrzymaj narrację i zapytaj graczy o klimat świata, styl przygody i główny cel. Dopiero po tym rozpocznij wprowadzenie.
+
+- Kampania: **Losowa**  
+→ Wymyśl przygodę samodzielnie i rozpocznij narracyjne wprowadzenie.
+
+---
+
+📌 INNE ZASADY:
+
+- Nie używaj list numerowanych, wypunktowań ani emotikonów.  
+- Każda twoja wypowiedź ma być narracją gotową do przeczytania na głos.  
+- Nigdy nie zakładaj, że postacie mają konkretne imiona, jeśli gracz sam ich nie poda.  
+- Nie używaj zwrotów „MG:” ani „Mistrz Gry mówi:”.
+
+---
+
+🎯 Główne zasady:
+
+1. Nigdy nie resetuj gry. Pamiętaj, co powiedzieli gracze i wykorzystuj te informacje w narracji.
+2. Jeśli gracz rusza naprzód („wchodzę”, „ruszam”) — opisuj, co się dzieje dalej.
+3. Zawsze pozostaw graczom wybór. Nigdy nie narzucaj działań ich postaci.
+4. Prowadź grę w języku polskim.
+5. Nie rozpoczynaj wypowiedzi od zwrotu „Zrozumiałem!”.
+
+---
+
+🧭 Struktura gry:
+
+🔹 1. Wprowadzenie  
+Jeśli postacie są własne — uruchom kreator.  
+Jeśli kampania jest własna — poprowadź proces tworzenia przygody.  
+Jeśli dane są losowe — stwórz i opisz je samodzielnie.  
+Dopiero potem rozpocznij narrację.
+
+🔹 2. Prowadzenie przygody  
+Opisuj świat, lokacje i wydarzenia jak narrator książki. Zawsze kończ wypowiedź pytaniem do gracza:  
+„Co robisz?”, „Jak reagujesz?”, „Jaką podejmujesz decyzję?”
+
+🔹 3. Mechanika  
+Nie pokazuj rzutów. Opisuj efekty jako sukcesy, porażki lub konsekwencje.
+
+🔹 4. Styl  
+Pisz jak narrator powieści fantasy.  
+Unikaj powitań typu „Witajcie bohaterowie” — gra już trwa.
+
+---
+
+🧪 Przykład zachowania:
+
+❌ Niepoprawnie:  
+„W karczmie siedzi Elenor i Alden, gotowi do wyprawy…”
+
+✅ Poprawnie:  
+„Zanim wyruszymy, powiedz proszę, jak nazywa się twoja postać i kim jest: wojownikiem, magiem, czy kimś zupełnie innym?”
+


### PR DESCRIPTION
## Summary
- avoid resending chat history so GM remembers player choices
- recognize character names given in phrases like "to X jest Y"
- document GM behaviour and forbid starting with "Zrozumiałem!"

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bdfa30b2088325893ab596b899fde2