### PR TITLE
Replace ElevenLabs TTS with OpenAI

### DIFF
--- a/Desktop/NEW GM/ai-gm-week2/apps/server/src/gmAssistants.ts
+++ b/Desktop/NEW GM/ai-gm-week2/apps/server/src/gmAssistants.ts
@@ -149,34 +149,19 @@ router.post("/run", async (req, res) => {
 router.post("/speech", async (req, res) => {
   try {
     const { text } = req.body ?? {};
-    const key = process.env.ELEVENLABS_KEY;
-    const voice = process.env.VOICE_ID;
 
     if (!text) {
       return res.status(400).json({ error: "text required" });
     }
-    if (!key || !voice) {
-      console.warn("[gmAssistants] Missing ELEVENLABS_KEY or VOICE_ID");
-      return res.status(500).json({ error: "tts not configured" });
-    }
 
-    const r = await fetch(`https://api.elevenlabs.io/v1/text-to-speech/${voice}`, {
-      method: "POST",
-      headers: {
-        "xi-api-key": key,
-        Accept: "audio/mpeg",
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ text }),
+    // Generate speech with OpenAI's TTS model
+    const speech = await client.audio.speech.create({
+      model: "gpt-4o-mini-tts",
+      voice: "alloy",
+      input: text,
     });
 
-    if (!r.ok) {
-      const err = await r.text();
-      console.error("[/api/gm/speech] TTS failed:", r.status, err);
-      return res.status(500).json({ error: "tts failed", detail: err });
-    }
-
-    const buf = Buffer.from(await r.arrayBuffer());
+    const buf = Buffer.from(await speech.arrayBuffer());
     res.setHeader("Content-Type", "audio/mpeg");
     res.send(buf);
   } catch (e: any) {


### PR DESCRIPTION
## Summary
- swap ElevenLabs text-to-speech for OpenAI's gpt-4o-mini-tts in `/speech` endpoint
- remove unused ElevenLabs configuration checks

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build:server`

------
https://chatgpt.com/codex/tasks/task_e_68bf29bcd6bc832590ee55976dd2e0ff