### PR TITLE
feat: remember player statements for GM

### DIFF
--- a/Desktop/NEW GM/ai-gm-week2/apps/server/src/memory.ts
+++ b/Desktop/NEW GM/ai-gm-week2/apps/server/src/memory.ts
@@ -1,0 +1,27 @@
+export type Memory = {
+  threadId: string;
+  entries: string[];
+};
+
+const store = new Map<string, string[]>();
+
+export function addPlayerMessage(threadId: string, content: string) {
+  if (!store.has(threadId)) {
+    store.set(threadId, []);
+  }
+  const arr = store.get(threadId)!;
+  arr.push(content);
+  if (arr.length > 50) {
+    arr.splice(0, arr.length - 50); // keep last 50 messages
+  }
+}
+
+export function getMemorySummary(threadId: string): string {
+  const arr = store.get(threadId);
+  if (!arr || arr.length === 0) return '';
+  return arr.join('\n');
+}
+
+export function clearMemory(threadId: string) {
+  store.delete(threadId);
+}


### PR DESCRIPTION
## Summary
- track player messages per thread for recall
- pass stored statements to assistant runs as extra instructions

## Testing
- `npm --prefix "Desktop/NEW GM/ai-gm-week2" run build:server`


------
https://chatgpt.com/codex/tasks/task_e_68c0710cdcb08325943c741f2cad37db