### PR TITLE
Sanitize GM replies for voice playback

### DIFF
--- a/Desktop/NEW GM/ai-gm-week2/apps/client/src/GmChat.tsx
+++ b/Desktop/NEW GM/ai-gm-week2/apps/client/src/GmChat.tsx
@@ -2,6 +2,15 @@ import React from 'react';
 
 type Msg = { from: 'gm' | 'me'; text: string };
 
+function sanitize(text: string): string {
+  return text
+    .replace(/[*_`~]/g, '')
+    .split('\n')
+    .map((line) => line.replace(/^[-•\d.]+\s*/, '').trim())
+    .filter(Boolean)
+    .join(' ');
+}
+
 export default function GmChat({
   campaignId,
   setup,
@@ -181,8 +190,9 @@ export default function GmChat({
         throw new Error(`run ${r2.status}: ${errorText}`);
       }
       const { reply } = await r2.json();
-      setLog((l) => [...l, { from: 'gm', text: reply }]);
-      speak(reply);
+      const clean = sanitize(reply);
+      setLog((l) => [...l, { from: 'gm', text: clean }]);
+      speak(clean);
     } catch (e: any) {
       console.error('[GmChat] Error in sendInternal:', e);
       setError('Problem z odpowiedzią MG. Sprawdź połączenie i spróbuj ponownie.');

--- a/Desktop/NEW GM/ai-gm-week2/apps/server/src/gmAssistants.ts
+++ b/Desktop/NEW GM/ai-gm-week2/apps/server/src/gmAssistants.ts
@@ -16,6 +16,15 @@ if (!ASSISTANT_ID) {
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
+function sanitize(text: string): string {
+  return text
+    .replace(/[*_`~]/g, "")
+    .split("\n")
+    .map((line) => line.replace(/^[-•\d.]+\s*/, "").trim())
+    .filter(Boolean)
+    .join(" ");
+}
+
 // Minimal shapes for messages
 type MsgPart =
   | { type: "text"; text: { value: string } }
@@ -148,6 +157,7 @@ router.post("/run", async (req, res) => {
       });
     }
 
+    reply = sanitize(reply);
     console.log("[/api/gm/run] Reply received, length:", reply.length);
     res.json({ reply });
   } catch (e: any) {


### PR DESCRIPTION
## Summary
- strip markdown special characters and list formatting from GM assistant replies on the server
- sanitize replies on the client before display and text-to-speech

## Testing
- `npm --prefix 'Desktop/NEW GM/ai-gm-week2' test` *(fails: Missing script: "test")*
- `npm --prefix 'Desktop/NEW GM/ai-gm-week2/apps/server' install`
- `npm --prefix 'Desktop/NEW GM/ai-gm-week2/apps/server' run build`


------
https://chatgpt.com/codex/tasks/task_e_68c325871ed08325be40d60d45ca1aea